### PR TITLE
fixed duplicate dash and underscore in the numeric keyboard

### DIFF
--- a/app/src/main/java/com/techlads/composetvkeyboard/data/KeysDataSource.kt
+++ b/app/src/main/java/com/techlads/composetvkeyboard/data/KeysDataSource.kt
@@ -111,9 +111,9 @@ object KeysDataSource {
         // Row five
         add(ABC)
         add(Clear)
-        add(Underscore)
+        add(Dot)
         add(Space)
-        add(Dash)
+        add(Comma)
         add(ActionArrow)
     }
 


### PR DESCRIPTION
fixed duplicate dash and underscore in the numeric keyboard view which caused crashes

Fixes #63